### PR TITLE
v1.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018, go-httpproxy authors.
+Copyright (c) 2018, "httpproxy" authors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the go-httpproxy authors nor the
+    * Neither the name of the "httpproxy" authors nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,12 @@
 
 [![GoDoc](https://godoc.org/github.com/go-httpproxy/httpproxy?status.svg)](https://godoc.org/github.com/go-httpproxy/httpproxy)
 
-## Introduction
-
-`github.com/go-httpproxy/httpproxy` repository provides an HTTP proxy library
-for Go (golang).
-
-The library is a customizable HTTP proxy; supports HTTP, HTTPS through CONNECT.
-And also provides HTTPS connection using "Man in the Middle" style attack.
+Package httpproxy provides a customizable HTTP proxy; supports HTTP, HTTPS through
+CONNECT. And also provides HTTPS connection using "Man in the Middle" style
+attack.
 
 It's easy to use. `httpproxy.Proxy` implements `Handler` interface of `net/http`
 package to offer `http.ListenAndServe` function.
-
-### Keep it simple, stupid!
-
-> KISS is an acronym for "Keep it simple, stupid" as a design principle. The
-KISS principle states that most systems work best if they are kept simple rather
-than made complicated; therefore simplicity should be a key goal in design and
-unnecessary complexity should be avoided.  [Wikipedia]
 
 ## Usage
 
@@ -29,7 +18,7 @@ Library has two significant structs: Proxy and Context.
 ```go
 // Proxy defines parameters for running an HTTP Proxy. It implements
 // http.Handler interface for ListenAndServe function. If you need, you must
-// fill Proxy struct before handling requests.
+// set Proxy struct before handling requests.
 type Proxy struct {
 	// Session number of last proxy request.
 	SessionNo int64
@@ -70,8 +59,12 @@ type Proxy struct {
 	OnResponse func(ctx *Context, req *http.Request, resp *http.Response)
 
 	// If ConnectAction is ConnectMitm, it sets chunked to Transfer-Encoding.
-	// By default, it is true.
+	// By default, true.
 	MitmChunked bool
+
+	// HTTP Authentication type. If it's not specified (""), uses "Basic".
+	// By default, "".
+	AuthType string
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,78 @@ type Context struct {
 }
 ```
 
+### Demo code
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/go-httpproxy/httpproxy"
+)
+
+func OnError(ctx *httpproxy.Context, when string,
+	err *httpproxy.Error, opErr error) {
+	// Log errors.
+	log.Printf("ERR: %s: %s [%s]", when, err, opErr)
+}
+
+func OnAccept(ctx *httpproxy.Context, w http.ResponseWriter,
+	r *http.Request) bool {
+	// Handle local request has path "/info"
+	if r.Method == "GET" && !r.URL.IsAbs() && r.URL.Path == "/info" {
+		w.Write([]byte("This is go-httpproxy."))
+		return true
+	}
+	return false
+}
+
+func OnAuth(ctx *httpproxy.Context, user string, pass string) bool {
+	// Auth test user.
+	if user == "test" && pass == "1234" {
+		return true
+	}
+	return false
+}
+
+func OnConnect(ctx *httpproxy.Context, host string) (
+	ConnectAction httpproxy.ConnectAction, newHost string) {
+	// Apply "Man in the Middle" to all ssl connections. Never change host.
+	return httpproxy.ConnectMitm, host
+}
+
+func OnRequest(ctx *httpproxy.Context, req *http.Request) (
+	resp *http.Response) {
+	// Log proxying requests.
+	log.Printf("INFO: Proxy: %s %s", req.Method, req.URL.String())
+	return
+}
+
+func OnResponse(ctx *httpproxy.Context, req *http.Request,
+	resp *http.Response) {
+	// Add header "Via: go-httpproxy".
+	resp.Header.Add("Via", "go-httpproxy")
+}
+
+func main() {
+	// Create a new proxy with default certificate pair.
+	prx, _ := httpproxy.NewProxy()
+
+	// Set handlers.
+	prx.OnError = OnError
+	prx.OnAccept = OnAccept
+	prx.OnAuth = OnAuth
+	prx.OnConnect = OnConnect
+	prx.OnRequest = OnRequest
+	prx.OnResponse = OnResponse
+
+	// Listen...
+	http.ListenAndServe(":8080", prx)
+}
+```
+
 ## GoDoc
 
 [https://godoc.org/github.com/go-httpproxy/httpproxy](https://godoc.org/github.com/go-httpproxy/httpproxy)

--- a/ca.go
+++ b/ca.go
@@ -10,6 +10,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -99,6 +100,74 @@ GK7KSSnouV5LAtvyDVTu+b6IAguOiIW6d+9T4H3QwnnQeyKE+5NWc3fB4dPqc5AS
 s39uFDUnxsMb2Nl3JcNJHYBTm9ubjAZSo/3NuB0z/Gm+ssOcExTD//vW7BxxSAcs
 /xlPPTPbY5qoMAT7kK71kd4Ypnqbcs3UPpAHtcPkjWpuWOlebK0J7UYToj4f
 -----END RSA PRIVATE KEY-----`)
+
+type CaSigner struct {
+	Ca        *tls.Certificate
+	mu        sync.RWMutex
+	certMap   map[string]*tls.Certificate
+	certList  []string
+	certIndex int
+	certMax   int
+}
+
+func NewCaSigner() *CaSigner {
+	return NewCaSignerCache(0)
+}
+
+func NewCaSignerCache(max int) *CaSigner {
+	if max < 0 {
+		max = 0
+	}
+	return &CaSigner{
+		certMap:   make(map[string]*tls.Certificate),
+		certList:  make([]string, max),
+		certIndex: 0,
+		certMax:   max,
+	}
+}
+
+func (c *CaSigner) SignHost(host string) (cert *tls.Certificate) {
+	if host == "" {
+		return
+	}
+	if c.certMax <= 0 {
+		crt, err := signHosts(*c.Ca, []string{host})
+		if err != nil {
+			return nil
+		}
+		cert = &crt
+		return
+	}
+	func() {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		cert = c.certMap[host]
+	}()
+	if cert != nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cert = c.certMap[host]
+	if cert != nil {
+		return
+	}
+	crt, err := signHosts(*c.Ca, []string{host})
+	if err != nil {
+		return nil
+	}
+	cert = &crt
+	if len(c.certMap) >= c.certMax {
+		delete(c.certMap, c.certList[c.certIndex])
+	}
+	c.certMap[host] = cert
+	c.certList[c.certIndex] = host
+	c.certIndex++
+	if c.certIndex >= c.certMax {
+		c.certIndex = 0
+	}
+	return
+}
 
 func signHosts(ca tls.Certificate, hosts []string) (cert tls.Certificate, error error) {
 	var x509ca *x509.Certificate

--- a/demo/main.go
+++ b/demo/main.go
@@ -7,43 +7,61 @@ import (
 	"github.com/go-httpproxy/httpproxy"
 )
 
-func OnError(ctx *httpproxy.Context, when string, err *httpproxy.Error, opErr error) {
-	log.Printf("%s %s %s", when, err, opErr)
+func OnError(ctx *httpproxy.Context, when string,
+	err *httpproxy.Error, opErr error) {
+	// Log errors.
+	log.Printf("ERR: %s: %s [%s]", when, err, opErr)
 }
 
-func OnAccept(ctx *httpproxy.Context, w http.ResponseWriter, r *http.Request) bool {
+func OnAccept(ctx *httpproxy.Context, w http.ResponseWriter,
+	r *http.Request) bool {
+	// Handle local request has path "/info"
+	if r.Method == "GET" && !r.URL.IsAbs() && r.URL.Path == "/info" {
+		w.Write([]byte("This is go-httpproxy."))
+		return true
+	}
 	return false
 }
 
 func OnAuth(ctx *httpproxy.Context, user string, pass string) bool {
+	// Auth test user.
 	if user == "test" && pass == "1234" {
 		return true
 	}
 	return false
 }
 
-func OnConnect(ctx *httpproxy.Context, host string) (ConnectAction httpproxy.ConnectAction, newHost string) {
+func OnConnect(ctx *httpproxy.Context, host string) (
+	ConnectAction httpproxy.ConnectAction, newHost string) {
+	// Apply "Man in the Middle" to all ssl connections. Never change host.
 	return httpproxy.ConnectMitm, host
 }
 
-func OnRequest(ctx *httpproxy.Context, req *http.Request) (resp *http.Response) {
-	log.Printf("Request %s", req.URL.String())
+func OnRequest(ctx *httpproxy.Context, req *http.Request) (
+	resp *http.Response) {
+	// Log proxying requests.
+	log.Printf("INFO: Proxy: %s %s", req.Method, req.URL.String())
 	return
 }
 
-func OnResponse(ctx *httpproxy.Context, req *http.Request, resp *http.Response) {
-	resp.Header.Add("Via", "test")
+func OnResponse(ctx *httpproxy.Context, req *http.Request,
+	resp *http.Response) {
+	// Add header "Via: go-httpproxy".
+	resp.Header.Add("Via", "go-httpproxy")
 }
 
 func main() {
+	// Create a new proxy with default certificate pair.
 	prx, _ := httpproxy.NewProxy()
+
+	// Set handlers.
 	prx.OnError = OnError
 	prx.OnAccept = OnAccept
 	prx.OnAuth = OnAuth
 	prx.OnConnect = OnConnect
 	prx.OnRequest = OnRequest
 	prx.OnResponse = OnResponse
-	prx.MitmChunked = true
 
+	// Listen...
 	http.ListenAndServe(":8080", prx)
 }

--- a/doing.go
+++ b/doing.go
@@ -153,13 +153,13 @@ func doConnect(ctx *Context, w http.ResponseWriter, r *http.Request) (w2 http.Re
 		remoteConn.Close()
 	case ConnectMitm:
 		tlsConfig := &tls.Config{}
-		cert, err := signHosts(ctx.Prx.Ca, []string{stripPort(host)})
-		if err != nil {
+		cert := ctx.Prx.signer.SignHost(stripPort(host))
+		if cert == nil {
 			hijConn.Close()
 			doError(ctx, "Connect", ErrTLSSignHost, err)
 			return
 		}
-		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+		tlsConfig.Certificates = append(tlsConfig.Certificates, *cert)
 		if _, err := hijConn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n")); err != nil {
 			hijConn.Close()
 			if !isConnectionClosed(err) {

--- a/doing.go
+++ b/doing.go
@@ -88,9 +88,6 @@ func doConnect(ctx *Context, w http.ResponseWriter, r *http.Request) (w2 http.Re
 	if ctx.Prx.OnConnect != nil {
 		var newHost string
 		ctx.ConnectAction, newHost = ctx.Prx.OnConnect(ctx, host)
-		if ctx.ConnectAction == ConnectNone {
-			ctx.ConnectAction = ConnectProxy
-		}
 		if newHost != "" {
 			host = newHost
 		}
@@ -162,7 +159,8 @@ func doConnect(ctx *Context, w http.ResponseWriter, r *http.Request) (w2 http.Re
 		}
 		ctx.hijTLSReader = bufio.NewReader(ctx.hijTLSConn)
 		w2 = NewConnResponseWriter(ctx.hijTLSConn)
-		return
+	default:
+		hijConn.Close()
 	}
 	return
 }

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -76,6 +76,8 @@ type Proxy struct {
 	// If ConnectAction is ConnectMitm, it sets chunked to Transfer-Encoding.
 	// By default, it is true.
 	MitmChunked bool
+
+	AuthType string
 }
 
 // NewProxy returns a new Proxy has default CA certificate and key.

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -150,7 +150,7 @@ func (prx *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		if b, err := doResponse(ctx, w, r); err != nil || !b || !cyclic {
+		if err := doResponse(ctx, w, r); err != nil || !cyclic {
 			break
 		}
 	}

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -12,7 +12,7 @@ type ConnectAction int
 // Constants of ConnectAction type.
 const (
 	// ConnectNone specifies that proxy request is not CONNECT.
-	// If it returned in OnConnect, changed to ConnectProxy.
+	// If it returned in OnConnect, proxy connection closes immediately.
 	ConnectNone = ConnectAction(iota)
 
 	// ConnectProxy specifies directly socket proxy after the CONNECT.
@@ -109,13 +109,15 @@ func (prx *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if w2 := doConnect(ctx, w, r); w2 != nil {
 		w = w2
+		r = nil
 	} else {
 		return
 	}
 
 	for {
 		var cyclic = false
-		if ctx.ConnectAction == ConnectMitm {
+		switch ctx.ConnectAction {
+		case ConnectMitm:
 			if prx.MitmChunked {
 				cyclic = true
 			}

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -118,8 +118,10 @@ func (prx *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	removeProxyHeaders(r)
 
 	if w2 := doConnect(ctx, w, r); w2 != nil {
-		w = w2
-		r = nil
+		if w != w2 {
+			w = w2
+			r = nil
+		}
 	} else {
 		return
 	}

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -78,6 +78,8 @@ type Proxy struct {
 	MitmChunked bool
 
 	AuthType string
+
+	signer *CaSigner
 }
 
 // NewProxy returns a new Proxy has default CA certificate and key.
@@ -89,8 +91,11 @@ func NewProxy() (*Proxy, error) {
 func NewProxyCert(caCert, caKey []byte) (result *Proxy, error error) {
 	result = &Proxy{
 		Rt: &http.Transport{TLSClientConfig: &tls.Config{},
-			Proxy: http.ProxyFromEnvironment}, MitmChunked: true,
+			Proxy: http.ProxyFromEnvironment},
+		MitmChunked: true,
+		signer:      NewCaSignerCache(1024),
 	}
+	result.signer.Ca = &result.Ca
 	if caCert == nil {
 		caCert = DefaultCaCert
 	}

--- a/httpproxy.go
+++ b/httpproxy.go
@@ -33,7 +33,7 @@ const (
 
 // Proxy defines parameters for running an HTTP Proxy. It implements
 // http.Handler interface for ListenAndServe function. If you need, you must
-// fill Proxy struct before handling requests.
+// set Proxy struct before handling requests.
 type Proxy struct {
 	// Session number of last proxy request.
 	SessionNo int64
@@ -74,9 +74,11 @@ type Proxy struct {
 	OnResponse func(ctx *Context, req *http.Request, resp *http.Response)
 
 	// If ConnectAction is ConnectMitm, it sets chunked to Transfer-Encoding.
-	// By default, it is true.
+	// By default, true.
 	MitmChunked bool
 
+	// HTTP Authentication type. If it's not specified (""), uses "Basic".
+	// By default, "".
 	AuthType string
 
 	signer *CaSigner

--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // InMemoryResponse creates new HTTP response given arguments.
@@ -46,6 +47,13 @@ func ServeResponse(w http.ResponseWriter, resp *http.Response) error {
 		for _, v1 := range v {
 			h.Add(k, v1)
 		}
+	}
+	if h.Get("Date") == "" {
+		//h.Set("Date", time.Now().UTC().Format(time.RFC1123))
+		h.Set("Date", time.Now().UTC().Format("Mon, 2 Jan 2006 15:04:05")+" GMT")
+	}
+	if h.Get("Content-Type") == "" {
+		h.Set("Content-Type", "text/plain; charset=utf-8")
 	}
 	if resp.ContentLength >= 0 {
 		h.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))


### PR DESCRIPTION
* Added unauthorized header in doAuth
* Added Proxy.AuthType
* Return 502 for unreachable addresses
* Added Date, Content-Type headers in ServeResponse if they absent
* Added signed hosts cache (CaSigner)
* Added GoDoc