### PR TITLE
Added OnDial option which allows overriding dialing

### DIFF
--- a/context.go
+++ b/context.go
@@ -65,6 +65,20 @@ func (ctx *Context) onAuth(authType string, user string, pass string) bool {
 	return ctx.Prx.OnAuth(ctx, authType, user, pass)
 }
 
+func (ctx *Context) onDial(network, addr string) (c net.Conn, err error) {
+	defer func() {
+		if err, ok := recover().(error); ok {
+			ctx.doError("Dial", ErrPanic, err)
+		}
+	}()
+	if ctx.Prx.OnDial != nil {
+		return ctx.Prx.OnDial(network, addr)
+	} else {
+		return net.Dial(network, addr)
+	}
+
+}
+
 func (ctx *Context) onConnect(host string) (ConnectAction ConnectAction,
 	newHost string) {
 	defer func() {
@@ -208,7 +222,8 @@ func (ctx *Context) doConnect(w http.ResponseWriter, r *http.Request) (b bool) {
 	ctx.ConnectHost = host
 	switch ctx.ConnectAction {
 	case ConnectProxy:
-		conn, err := net.Dial("tcp", host)
+
+		conn, err := ctx.onDial("tcp", host)
 		if err != nil {
 			hijConn.Write([]byte("HTTP/1.1 404 Not Found\r\n\r\n"))
 			hijConn.Close()

--- a/proxy.go
+++ b/proxy.go
@@ -2,6 +2,7 @@ package httpproxy
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"sync/atomic"
 )
@@ -39,6 +40,8 @@ type Proxy struct {
 	// If len(newhost) > 0, host changes.
 	OnConnect func(ctx *Context, host string) (ConnectAction ConnectAction,
 		newHost string)
+
+	OnDial func(network string, addr string) (c net.Conn, err error)
 
 	// Request callback. It greets remote request.
 	// If it returns non-nil response, stops processing remote request.


### PR DESCRIPTION
This change allows to override dial.

For example, run http proxy over socks proxy

```
var (
	socksDialer proxy.Dialer = nil
)

func runHttpProxy(sock5Port, httpPort uint) error {

	var err error

	// create a socks5 dialer
	addr := fmt.Sprintf("127.0.0.1:%d", sock5Port)
	socksDialer, err = proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
	if err != nil {
		return err
	}

	prx, _ := httpproxy.NewProxy()
	prx.OnDial = onHttpProxyDial

	addr = fmt.Sprintf(":%d", httpPort)
	return http.ListenAndServe(addr, prx)
}

func onHttpProxyDial(network, addr string) (conn net.Conn, err error) {
	return socksDialer.Dial(network, addr)
}

```